### PR TITLE
Implemented withCssHandles higher order component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `withCssHandles` higher order component.
 
 ## [0.3.1] - 2019-10-04
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,8 @@ const Component: FunctionComponent = () => {
           {['blue', 'yellow', 'green'].map(color => (
             <li
               className={`${applyModifiers(handles.item, color)} bg-${color}`}>
-              {/*             ˜˜˜˜˜˜˜˜˜˜˜˜˜˜ Appends modifier suffixes to the CSS handles, for selection of specific items.
+              {/*           ˜˜˜˜˜˜˜˜˜˜˜˜˜˜
+               * Appends modifier suffixes to the CSS handles, for selection of specific items.
                *                         For example, `handle handle--blockClass handle--color handle--blockClass--color` */}
               Color {color}
             </li>
@@ -45,7 +46,7 @@ const Component: FunctionComponent = () => {
 import React, { Component } from 'react'
 import { withCssHandles } from from 'vtex.css-handles'
 
-const CSS_HANDLES = ['container', 'background', 'text', 'item'] as const
+const CSS_HANDLES = ['container', 'background', 'text'] as const
 
 class ExampleComponent extends Component {
 
@@ -55,16 +56,7 @@ class ExampleComponent extends Component {
     return (
       <div className={cssHandles.container}>
         <div className={`${cssHandles.background} bg-red`}>
-          <h1 className={`${cssHandles.text} f1 c-white`}>Hello world</h1>
-          <ul>
-            {['blue', 'yellow', 'green'].map(color => (
-              <li className={`${applyModifiers(cssHandles.item, color)} bg-${color}`}>
-                {/*             ˜˜˜˜˜˜˜˜˜˜˜˜˜˜ Appends modifier suffixes to the CSS handles, for selection of specific items.
-                *                         For example, `handle handle--blockClass handle--color handle--blockClass--color` */}
-                Color {color}
-              </li>
-            ))}
-          </ul>
+          <div className={`${cssHandles.text} f1 c-white`}>Hello world</div>
         </div>
       </div>
     )

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,11 +6,13 @@ Utility for generating CSS handles for store components.
 
 ## Usage
 
+### useCssHandles
+
 ```tsx
 import React, { FunctionComponent } from 'react'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 
-const CSS_HANDLES = ['container', 'background', 'title', 'item'] as const
+const CSS_HANDLES = ['container', 'background', 'text', 'item'] as const
 /* Using `as const at the end` hints to Typescript that this array
  * won't change, thus allowing autocomplete and other goodies. */
 
@@ -23,7 +25,8 @@ const Component: FunctionComponent = () => {
         <h1 className={`${handles.text} f1 c-white`}>Hello world</h1>
         <ul>
           {['blue', 'yellow', 'green'].map(color => (
-            <li className={`${applyModifiers(handle.item, color)} bg-${color}`}>
+            <li
+              className={`${applyModifiers(handles.item, color)} bg-${color}`}>
               {/*             ˜˜˜˜˜˜˜˜˜˜˜˜˜˜ Appends modifier suffixes to the CSS handles, for selection of specific items.
                *                         For example, `handle handle--blockClass handle--color handle--blockClass--color` */}
               Color {color}
@@ -36,13 +39,51 @@ const Component: FunctionComponent = () => {
 }
 ```
 
+### withCssHandles
+
+```tsx
+import React, { Component } from 'react'
+import { withCssHandles } from from 'vtex.css-handles'
+
+const CSS_HANDLES = ['container', 'background', 'text', 'item'] as const
+
+class ExampleComponent extends Component {
+
+  render() {
+    const { cssHandles } = this.props
+
+    return (
+      <div className={cssHandles.container}>
+        <div className={`${cssHandles.background} bg-red`}>
+          <h1 className={`${cssHandles.text} f1 c-white`}>Hello world</h1>
+          <ul>
+            {['blue', 'yellow', 'green'].map(color => (
+              <li className={`${applyModifiers(cssHandles.item, color)} bg-${color}`}>
+                {/*             ˜˜˜˜˜˜˜˜˜˜˜˜˜˜ Appends modifier suffixes to the CSS handles, for selection of specific items.
+                *                         For example, `handle handle--blockClass handle--color handle--blockClass--color` */}
+                Color {color}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default withCssHandles(CSS_HANDLES)(ExampleComponent)
+```
+
 ### Options
 
 - `migrationFrom`: Adds additional CSS handles for cases where a component is migrating from another app.
-  
+
 #### Usage:
+
 ```tsx
 const CSS_HANDLES = ['container']
-const handles = useCssHandles(CSS_HANDLES, { migrationFrom: 'vtex.store-components@3.x' })
+const handles = useCssHandles(CSS_HANDLES, {
+  migrationFrom: 'vtex.store-components@3.x',
+})
 // Returns { container: 'vtex-current-app-0-x-container vtex-store-components-3-x-container' }
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ const Component: FunctionComponent = () => {
 import React, { Component } from 'react'
 import { withCssHandles } from from 'vtex.css-handles'
 
-const CSS_HANDLES = ['container', 'background', 'text'] as const
+const CSS_HANDLES = ['text'] as const
 
 class ExampleComponent extends Component {
 
@@ -54,11 +54,7 @@ class ExampleComponent extends Component {
     const { cssHandles } = this.props
 
     return (
-      <div className={cssHandles.container}>
-        <div className={`${cssHandles.background} bg-red`}>
-          <div className={`${cssHandles.text} f1 c-white`}>Hello world</div>
-        </div>
-      </div>
+      <div className={`${cssHandles.text} f1 c-white`}>Hello world</div>
     )
   }
 }

--- a/react/__tests__/withCssHandles.test.tsx
+++ b/react/__tests__/withCssHandles.test.tsx
@@ -1,0 +1,111 @@
+import React, { Component } from 'react'
+import withCssHandles from '../withCssHandles'
+import { useExtension } from '../hooks/useExtension'
+import { render } from '@vtex/test-tools/react'
+
+type ValueOf<T extends readonly any[]> = T[number]
+
+type CssHandlesInput = readonly string[]
+type CssHandles<T extends CssHandlesInput> = Record<ValueOf<T>, string>
+interface CssHandlesOptions {
+  migrationFrom?: string | string[]
+}
+
+interface Props<T extends CssHandlesInput> {
+  cssHandles?: CssHandles<T>
+}
+
+class ExampleComponent<T extends CssHandlesInput> extends Component<Props<T>> {
+  public render() {
+    const cssHandles = this.props.cssHandles as CssHandles<T>
+
+    return (
+      <div
+        data-testid="test-div"
+        className={Object.values(cssHandles).join(' ')}></div>
+    )
+  }
+}
+
+jest.mock('../hooks/useExtension', () => ({
+  useExtension: jest.fn(() => ({
+    component: 'vtex.app@2.1.0',
+    props: {
+      blockClass: 'blockClass',
+    },
+  })),
+}))
+
+describe('withCssHandles', () => {
+  const renderComponent = (
+    handlesNames: CssHandlesInput,
+    options?: CssHandlesOptions
+  ) => {
+    const EnhancedComponent = withCssHandles<
+      typeof handlesNames,
+      Props<typeof handlesNames>
+    >(handlesNames, options)(ExampleComponent)
+
+    return render(<EnhancedComponent />)
+  }
+
+  it('should apply proper classes to proper handles', () => {
+    const CSS_HANDLES = ['element1', 'element2'] as const
+    const { getByTestId } = renderComponent(CSS_HANDLES)
+    expect(getByTestId('test-div').className).toBe(
+      'vtex-app-2-x-element1 vtex-app-2-x-element1--blockClass vtex-app-2-x-element2 vtex-app-2-x-element2--blockClass'
+    )
+  })
+  it('should not apply blockClasses if not available', () => {
+    const CSS_HANDLES = ['element1', 'element2'] as const
+    ;(useExtension as any).mockImplementationOnce(() => ({
+      component: 'vtex.app@2.1.0',
+      props: {},
+    }))
+
+    const { getByTestId } = renderComponent(CSS_HANDLES)
+    expect(getByTestId('test-div').className).toBe(
+      'vtex-app-2-x-element1 vtex-app-2-x-element2'
+    )
+  })
+  describe('migration', () => {
+    it('should add both the current app and the migration app', () => {
+      const CSS_HANDLES = ['element1', 'element2']
+      const options = {
+        migrationFrom: 'vtex.previous-app@3.0.0',
+      }
+
+      const { getByTestId } = renderComponent(CSS_HANDLES, options)
+      expect(getByTestId('test-div').className).toBe(
+        'vtex-app-2-x-element1 vtex-app-2-x-element1--blockClass vtex-previous-app-3-x-element1 vtex-previous-app-3-x-element1--blockClass vtex-app-2-x-element2 vtex-app-2-x-element2--blockClass vtex-previous-app-3-x-element2 vtex-previous-app-3-x-element2--blockClass'
+      )
+    })
+    it('should add more than one migration if needed', () => {
+      const CSS_HANDLES = ['element1', 'element2']
+      const options = {
+        migrationFrom: ['vtex.previous-app@2.0.0', 'vtex.previous-app@3.0.0'],
+      }
+
+      const { getByTestId } = renderComponent(CSS_HANDLES, options)
+      expect(getByTestId('test-div').className).toBe(
+        'vtex-app-2-x-element1 vtex-app-2-x-element1--blockClass vtex-previous-app-2-x-element1 vtex-previous-app-2-x-element1--blockClass vtex-previous-app-3-x-element1 vtex-previous-app-3-x-element1--blockClass vtex-app-2-x-element2 vtex-app-2-x-element2--blockClass vtex-previous-app-2-x-element2 vtex-previous-app-2-x-element2--blockClass vtex-previous-app-3-x-element2 vtex-previous-app-3-x-element2--blockClass'
+      )
+    })
+
+    it('doesnt repeat the migration if the current app happens to be the same as the migration one', () => {
+      const CSS_HANDLES = ['element1', 'element2']
+      const options = {
+        migrationFrom: [
+          'vtex.previous-app@2.0.0',
+          'vtex.previous-app@3.0.0',
+          'vtex.app@2.1.0',
+        ],
+      }
+
+      const { getByTestId } = renderComponent(CSS_HANDLES, options)
+      expect(getByTestId('test-div').className).toBe(
+        'vtex-app-2-x-element1 vtex-app-2-x-element1--blockClass vtex-previous-app-2-x-element1 vtex-previous-app-2-x-element1--blockClass vtex-previous-app-3-x-element1 vtex-previous-app-3-x-element1--blockClass vtex-app-2-x-element2 vtex-app-2-x-element2--blockClass vtex-previous-app-2-x-element2 vtex-previous-app-2-x-element2--blockClass vtex-previous-app-3-x-element2 vtex-previous-app-3-x-element2--blockClass'
+      )
+    })
+  })
+})

--- a/react/package.json
+++ b/react/package.json
@@ -5,14 +5,14 @@
   },
   "dependencies": {
     "apollo-client": "^2.6.3",
-    "react": "^16.8.6",
+    "react": "^16.10.1",
     "react-apollo": "^2.5.8",
     "react-dom": "^16.8.6",
     "react-intl": "^2.9.0"
   },
   "devDependencies": {
     "@types/graphql": "^14.2.2",
-    "@types/react": "^16.8.22",
+    "@types/react": "^16.9.4",
     "@types/react-intl": "^2.3.18",
     "@vtex/test-tools": "^0.3.2",
     "@vtex/tsconfig": "^0.2.0",

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,0 +1,11 @@
+import { FC } from 'react'
+import { TachyonsScaleInput } from '../hooks/tachyons'
+
+declare global {
+  interface CssHandlesOptions {
+    migrationFrom?: string | string[]
+  }
+  type CssHandlesInput = readonly string[]
+  type ValueOf<T extends readonly any[]> = T[number]
+  type CssHandles<T extends CssHandlesInput> = Record<ValueOf<T>, string>
+}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,11 +1,6 @@
-import { FC } from 'react'
-import { TachyonsScaleInput } from '../hooks/tachyons'
-
-declare global {
-  interface CssHandlesOptions {
-    migrationFrom?: string | string[]
-  }
-  type CssHandlesInput = readonly string[]
-  type ValueOf<T extends readonly any[]> = T[number]
-  type CssHandles<T extends CssHandlesInput> = Record<ValueOf<T>, string>
+interface CssHandlesOptions {
+  migrationFrom?: string | string[]
 }
+type CssHandlesInput = readonly string[]
+type ValueOf<T extends readonly any[]> = T[number]
+type CssHandles<T extends CssHandlesInput> = Record<ValueOf<T>, string>

--- a/react/useCssHandles.tsx
+++ b/react/useCssHandles.tsx
@@ -5,10 +5,6 @@ import applyModifiers from './applyModifiers'
 /** Verifies if the handle contains only letters and numbers, and does not begin with a number  */
 const validateCssHandle = (handle: string) => !/^\d|[^A-z0-9]/.test(handle)
 
-interface CssHandlesOptions {
-  migrationFrom?: string | string[]
-}
-
 const parseComponentName = (componentName: string) => {
   /* Matches until the first `.` or `@`.
    * Used to split something like `vtex.style-guide@2.0.1` into
@@ -109,10 +105,5 @@ const useCssHandles = <T extends CssHandlesInput>(
 
   return values
 }
-
-type ValueOf<T extends readonly any[]> = T[number]
-
-type CssHandlesInput = readonly string[]
-type CssHandles<T extends CssHandlesInput> = Record<ValueOf<T>, string>
 
 export default useCssHandles

--- a/react/withCssHandles.tsx
+++ b/react/withCssHandles.tsx
@@ -12,6 +12,9 @@ const withCssHandles = <T extends CssHandlesInput, ComponentProps>(
     return <Component cssHandles={cssHandles} {...props} />
   }
 
+  const displayName = Component.displayName || Component.name || 'Component'
+  EnhancedComponent.displayName = `withCssHandles(${displayName})`
+
   return EnhancedComponent
 }
 

--- a/react/withCssHandles.tsx
+++ b/react/withCssHandles.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import useCssHandles from './useCssHandles'
+import { ComponentType } from 'react'
+
+interface CssHandlesOptions {
+  migrationFrom?: string | string[]
+}
+type CssHandlesInput = readonly string[]
+
+const withCssHandles = <T extends CssHandlesInput, ComponentProps>(
+  handles: T,
+  options?: CssHandlesOptions
+) => (Component: ComponentType<ComponentProps>) => {
+  const EnhancedComponent = (props: ComponentProps) => {
+    const cssHandles = useCssHandles(handles, options)
+
+    return <Component cssHandles={cssHandles} {...props} />
+  }
+
+  return EnhancedComponent
+}
+
+export default withCssHandles

--- a/react/withCssHandles.tsx
+++ b/react/withCssHandles.tsx
@@ -2,15 +2,10 @@ import React from 'react'
 import useCssHandles from './useCssHandles'
 import { ComponentType } from 'react'
 
-interface CssHandlesOptions {
-  migrationFrom?: string | string[]
-}
-type CssHandlesInput = readonly string[]
-
 const withCssHandles = <T extends CssHandlesInput, ComponentProps>(
   handles: T,
   options?: CssHandlesOptions
-) => (Component: ComponentType<ComponentProps>) => {
+) => (Component: ComponentType<ComponentProps & { cssHandles: CssHandles<T> }>) => {
   const EnhancedComponent = (props: ComponentProps) => {
     const cssHandles = useCssHandles(handles, options)
 

--- a/react/withCssHandles.tsx
+++ b/react/withCssHandles.tsx
@@ -5,7 +5,9 @@ import { ComponentType } from 'react'
 const withCssHandles = <T extends CssHandlesInput, ComponentProps>(
   handles: T,
   options?: CssHandlesOptions
-) => (Component: ComponentType<ComponentProps & { cssHandles: CssHandles<T> }>) => {
+) => (
+  Component: ComponentType<ComponentProps & { cssHandles: CssHandles<T> }>
+) => {
   const EnhancedComponent = (props: ComponentProps) => {
     const cssHandles = useCssHandles(handles, options)
 

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1035,10 +1035,18 @@
   resolved "https://registry.yarnpkg.com/@types/react-intl/-/react-intl-2.3.18.tgz#fd2d8b7f4d0a1dd05b5f1784ab0d7fe1786a690d"
   integrity sha512-DVNJs49zUxKRZng8VuILE886Yihdsf3yLr5vHk9zJrmF8SyRSK3sxNSvikAKxNkv9hX55XBTJShz6CkJnbNjgg==
 
-"@types/react@^16.8.22", "@types/react@^16.8.7":
+"@types/react@^16.8.7":
   version "16.9.1"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.1.tgz#862c83b4c9d5cd116e42fd9a4f3694843cd2c051"
   integrity sha512-jGM2x8F7m7/r+81N/BOaUKVwbC5Cdw6ExlWEUpr77XPwVeNvAppnPEnMMLMfxRDYL8FPEX8MHjwtD2NQMJ0yyQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@^16.9.4":
+  version "16.9.4"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.4.tgz#de8cf5e5e2838659fb78fa93181078469eeb19fc"
+  integrity sha512-ItGNmJvQ0IvWt8rbk5PLdpdQhvBVxAaXI9hDlx7UMd8Ie1iMIuwMNiKeTfmVN517CdplpyXvA22X4zm4jGGZnw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -4318,7 +4326,16 @@ react-testing-library@^6.0.0:
     "@babel/runtime" "^7.4.2"
     dom-testing-library "^3.19.0"
 
-react@^16.8.4, react@^16.8.6:
+react@^16.10.1:
+  version "16.10.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.10.1.tgz#967c1e71a2767dfa699e6ba702a00483e3b0573f"
+  integrity sha512-2bisHwMhxQ3XQz4LiJJwG3360pY965pTl/MRrZYxIBKVj4fOHoDs5aZAkYXGxDRO1Li+SyjTAilQEbOmtQJHzA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+
+react@^16.8.4:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
   integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==


### PR DESCRIPTION
#### What does this PR do? \*
Create a `withCssHandles` higher-order component to be used in cases that you can't use the `useCssHandles`

#### How to test it? \*
Go to the react folder and run `yarn test`
