### PR TITLE
fix unnecessary extra spaces when filtering invalid modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Erase extra space when invalid modifier was filtered.
 
 ## [0.3.1] - 2019-10-04
 ### Fixed

--- a/react/__tests__/applyModifiers.test.tsx
+++ b/react/__tests__/applyModifiers.test.tsx
@@ -50,7 +50,7 @@ describe('applyModifier', () => {
       const modified = applyModifiers(handle, modifiers)
 
       expect(modified).toBe(
-        'vtex-app-2-x-handle vtex-app-2-x-handle--blockClass vtex-app-2-x-handle--ok vtex-app-2-x-handle--blockClass--ok  vtex-app-2-x-handle--test-2 vtex-app-2-x-handle--blockClass--test-2'
+        'vtex-app-2-x-handle vtex-app-2-x-handle--blockClass vtex-app-2-x-handle--ok vtex-app-2-x-handle--blockClass--ok vtex-app-2-x-handle--test-2 vtex-app-2-x-handle--blockClass--test-2'
       )
     })
     it('should not apply a modifier if its empty', () => {

--- a/react/applyModifiers.ts
+++ b/react/applyModifiers.ts
@@ -47,6 +47,7 @@ const applyModifiers = (handles: string, modifier: string | string[]) => {
         .join(' ')
         .trim()
     })
+    .filter(l => l.length > 0)
     .join(' ')
     .trim()
 


### PR DESCRIPTION
#### What does this PR do? \*

When an invalid modifier was filtered, a `" "` was being added to the resulting string. We remove it now.

#### How to test it? \*

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
