### PR TITLE
allow - on css handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Allow `-` on css handles.
 
 ## [0.3.2] - 2019-10-07
 ### Fixed

--- a/react/__tests__/useCssHandles.test.tsx
+++ b/react/__tests__/useCssHandles.test.tsx
@@ -29,16 +29,32 @@ describe('useCssHandles', () => {
   })
   it('should not apply blockClasses if not available', () => {
     const CSS_HANDLES = ['element1', 'element2']
-    ;(useExtension as any).mockImplementationOnce(() => ({
-      component: 'vtex.app@2.1.0',
-      props: {},
-    }))
+      ; (useExtension as any).mockImplementationOnce(() => ({
+        component: 'vtex.app@2.1.0',
+        props: {},
+      }))
 
     const handles = useCssHandles(CSS_HANDLES)
 
     expect(handles).toStrictEqual({
       element1: 'vtex-app-2-x-element1',
       element2: 'vtex-app-2-x-element2',
+    })
+  })
+  it('make invalid class names be transformed to empty strings', () => {
+    const CSS_HANDLES = ['element1', 'element-2', 'element+3', '4element']
+      ; (useExtension as any).mockImplementationOnce(() => ({
+        component: 'vtex.app@2.1.0',
+        props: {},
+      }))
+
+    const handles = useCssHandles(CSS_HANDLES)
+
+    expect(handles).toStrictEqual({
+      element1: 'vtex-app-2-x-element1',
+      'element-2': 'vtex-app-2-x-element-2',
+      'element+3': '',
+      '4element': '',
     })
   })
   describe('migration', () => {

--- a/react/useCssHandles.tsx
+++ b/react/useCssHandles.tsx
@@ -2,8 +2,8 @@ import { useMemo } from 'react'
 import { useExtension } from './hooks/useExtension'
 import applyModifiers from './applyModifiers'
 
-/** Verifies if the handle contains only letters and numbers, and does not begin with a number  */
-const validateCssHandle = (handle: string) => !/^\d|[^A-z0-9]/.test(handle)
+/** Verifies if the handle contains only letters, numbers and -, and does not begin with a number  */
+const validateCssHandle = (handle: string) => !/^\d|[^A-z0-9-]/.test(handle)
 
 interface CssHandlesOptions {
   migrationFrom?: string | string[]


### PR DESCRIPTION
On apps like `vtex.rich-text` we have classes like: `heading-level-1`. So I believe we should be able to allow `-` to handles.