### PR TITLE
Fix/editor blockclass 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Support for blockClass prop from Site Editor content. 
 
 ## [1.0.0] - 2020-12-08
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "css-handles",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "title": "CSS Handles",
   "description": "Utility for creating CSS Handles on store components",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "css-handles",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "title": "CSS Handles",
   "description": "Utility for creating CSS Handles on store components",
   "builders": {

--- a/react/useCssHandles.tsx
+++ b/react/useCssHandles.tsx
@@ -78,8 +78,8 @@ const useCssHandles = <T extends CssHandlesList>(
 ): CssHandlesBag<T> => {
   const extension = useExtension()
 
-  const { props = {}, component = '' } = extension ?? {}
-  const blockClass = props.cssHandle || props.blockClass
+  const { content = {}, props = {}, component = '' } = extension ?? {}
+  const blockClass = props.cssHandle || content.blockClass || props.blockClass
   const { migrationFrom, classes: handlesOverride } = options
 
   const values = useMemo<CssHandlesBag<T>>(() => {


### PR DESCRIPTION
#### What does this PR do? \*
Considers the content added from VTEX Site Editor to define the proper `blockClass` value. As common behavior, a value coming from the the Site Editor overwrites the one defined in the Store theme.

PS: For the moment, the current Site Editor schema does not support multiple values for the `blockClass` input (and this would require a bigger/major change in the component). Thus, if the application needs to include more than one class, it still can only be done by providing an array of values directly to the Store theme properties.

#### How to test it? \*
https://dandraft--lojavtex.myvtex.com/admin/cms/site-editor/about-us

#### Related to / Depends on \*
Solves Know Issue reported in:
https://help.vtex.com/known-issues/property-blockclass-from-infocard-not-working--LTEEWCaZx2unBWSEJFDw6
